### PR TITLE
Fix broken CI link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BMP280
 
 [![Hex version](https://img.shields.io/hexpm/v/bmp280.svg "Hex version")](https://hex.pm/packages/bmp280)
-[![CircleCI](https://circleci.com/gh/fhunleth/bmp280.svg?style=svg)](https://circleci.com/gh/fhunleth/bmp280)
+[![CircleCI](https://circleci.com/gh/elixir-sensors/bmp280.svg?style=svg)](https://circleci.com/gh/elixir-sensors/bmp280)
 
 Read temperature and pressure from Bosch
 [BMP280](https://www.bosch-sensortec.com/products/environmental-sensors/pressure-sensors/bmp280/),


### PR DESCRIPTION
This PR fixes the broken Circle CI link. It was caused by our renaming the project owner.