### PR TITLE
Make readme the main doc page

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -65,6 +65,7 @@ defmodule BMP280.MixProject do
   defp docs do
     [
       extras: ["README.md", "CHANGELOG.md"],
+      main: "readme",
       source_ref: "v#{@version}",
       source_url: @source_url,
       skip_undefined_reference_warnings_on: ["CHANGELOG.md"]


### PR DESCRIPTION
This PR makes README.md file be the main page of the project's online documentation. Currently the doc main page is a plain API reference list, which is fine; however README.md looks better and many other libraries use README.md as the main page.

![Screen Shot 2021-05-09 at 10 00 34 AM](https://user-images.githubusercontent.com/7563926/117574959-ba845e80-b0ad-11eb-8a20-fb6306968b9e.png)
