### PR TITLE
Halt genserver init when device not found

### DIFF
--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -131,19 +131,20 @@ defmodule BMP280 do
     bus_name = Keyword.get(args, :bus_name, "i2c-1")
     bus_address = Keyword.get(args, :bus_address, @default_bmp280_bus_address)
 
-    with {:ok, _} <- Circuits.I2C.discover_one([bus_address]),
-         {:ok, transport} <- Transport.open(bus_name, bus_address) do
-      state = %{
-        transport: transport,
-        calibration: nil,
-        sea_level_pa: Keyword.get(args, :sea_level_pa, @sea_level_pa),
-        sensor_type: nil,
-        last_measurement: nil
-      }
+    case Transport.open(bus_name, bus_address) do
+      {:ok, transport} ->
+        state = %{
+          transport: transport,
+          calibration: nil,
+          sea_level_pa: Keyword.get(args, :sea_level_pa, @sea_level_pa),
+          sensor_type: nil,
+          last_measurement: nil
+        }
 
-      {:ok, state, {:continue, :continue}}
-    else
-      _error -> {:stop, :bus_not_found}
+        {:ok, state, {:continue, :continue}}
+
+      {:error, reason} ->
+        {:stop, reason}
     end
   end
 

--- a/lib/bmp280/transport.ex
+++ b/lib/bmp280/transport.ex
@@ -9,11 +9,8 @@ defmodule BMP280.Transport do
 
   @spec open(String.t(), address()) :: {:ok, t()} | {:error, any()}
   def open(bus_name, address) do
-    with {:ok, _} <- Circuits.I2C.discover_one([address]),
-         {:ok, i2c} <- I2C.open(bus_name) do
+    with {:ok, i2c} <- I2C.open(bus_name) do
       {:ok, %__MODULE__{i2c: i2c, address: address}}
-    else
-      _error -> {:error, :device_not_found}
     end
   end
 

--- a/lib/bmp280/transport.ex
+++ b/lib/bmp280/transport.ex
@@ -9,7 +9,8 @@ defmodule BMP280.Transport do
 
   @spec open(String.t(), address()) :: {:ok, t()} | {:error, any()}
   def open(bus_name, address) do
-    with {:ok, i2c} <- I2C.open(bus_name) do
+    with {:ok, _} <- Circuits.I2C.discover_one([address]),
+         {:ok, i2c} <- I2C.open(bus_name) do
       {:ok, %__MODULE__{i2c: i2c, address: address}}
     end
   end

--- a/lib/bmp280/transport.ex
+++ b/lib/bmp280/transport.ex
@@ -12,6 +12,8 @@ defmodule BMP280.Transport do
     with {:ok, _} <- Circuits.I2C.discover_one([address]),
          {:ok, i2c} <- I2C.open(bus_name) do
       {:ok, %__MODULE__{i2c: i2c, address: address}}
+    else
+      _error -> {:error, :device_not_found}
     end
   end
 


### PR DESCRIPTION
## Issue

Currently `BMP280.start_link` always returns `{:ok, pid}` tuple even if no device is connected to the target board. It does not cause any serious issue, but the library user may get confused with the  `{:ok, pid}` tuple followed by an exception in `handle_continue` where we initialize the sensor.

## Cause

As I investigate it, the core issue was our `Transport.open` always returning `{:ok, transport}`.

## Solution

[Circuits.I2C.discover_one/2](https://hexdocs.pm/circuits_i2c/Circuits.I2C.html#discover_one/2) came in handy. All we need is ensure that the provided address is at least discoverable. Then we will stop that gen server and return `{:error, :bus_not_found}` if the address is not found. 

## Advantages

- The library users get an intuitive error tuple.
- No more internal cryptic explosion.

## Screenshots

### Before this PR is applied

![nerves local_sessions_u7y7tvgy7vvxecyuan2xvqx3gzjtgku6 (1)](https://user-images.githubusercontent.com/7563926/118326223-afc53180-b4d2-11eb-8d51-aa256c47a6ad.png)

### After this PR is applied

updated with the commit `Use Comm.sensor_type for detecting device presence 25338a9`

![nerves local_ (2)](https://user-images.githubusercontent.com/7563926/118364842-311ad380-b568-11eb-9098-a8619576ea3c.png)

### Notes

Looks like it is currently a feature that Circuits.I2C recognizes "i2c-1" even if nothing is connected on any bus. https://github.com/elixir-circuits/circuits_i2c/issues/75

I used Raspberry Pi Zero W + https://github.com/fhunleth/nerves_livebook

```elixir
iex(livebook_gq7x2c5s@nerves-9bd5)1> Circuits.I2C.open("i2c-1")
{:ok, #Reference<0.856605456.268828681.72219>}

iex(livebook_gq7x2c5s@nerves-9bd5)2> Circuits.I2C.open("i2c-2")
{:error, :bus_not_found}

iex(livebook_gq7x2c5s@nerves-9bd5)3> Circuits.I2C.open("i2c-1")
{:ok, #Reference<0.856605456.268828681.72220>}

iex(livebook_gq7x2c5s@nerves-9bd5)4> Circuits.I2C.bus_names
["i2c-1"]
```
