### PR TITLE
v0.2.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.2.7
+
+* Improvements
+  * Update Circle config for OTP 24
+  * Remove the "Support for other Bosch barometric sensors" section from README
+
+* Fixes
+  * Halt the sensor initialization when device is not found
+
 ## v0.2.6
 
 * Improvements

--- a/README.md
+++ b/README.md
@@ -49,9 +49,3 @@ Subsequent altitude reports should be more accurate until the weather changes.
 ## Nerves Livebook Firmware
 
 [Nerves Livebook Firmware](https://github.com/fhunleth/nerves_livebook) contains BMP280 example, which shows you how to work with the BMP280 sensor on the [Nerves](https://www.nerves-project.org/) projects with example code that is runnable from the comfort of your browser.
-
-## Support for other Bosch barometric sensors
-
-Other Bosch sensors tend to look similar, but they have enough differences that
-they do not work yet. If you're using one of them, please help me by either
-verifying that they work or adding support for them.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule BMP280.MixProject do
   use Mix.Project
 
-  @version "0.2.6"
+  @version "0.2.7"
   @source_url "https://github.com/elixir-sensors/bmp280"
 
   def project do


### PR DESCRIPTION
Other than all the commits since last release, I found the "Support for other Bosch barometric sensors" section of README no longer relevant since we now support BME680. I am planning to support BMP388 as well.