### PR TITLE
Refactor comm modules

### DIFF
--- a/lib/bmp280/comm/bme280_comm.ex
+++ b/lib/bmp280/comm/bme280_comm.ex
@@ -1,7 +1,7 @@
 defmodule BMP280.BME280Comm do
   @moduledoc false
 
-  alias BMP280.{BME280Sensor, Transport}
+  alias BMP280.Transport
 
   @calib00_register 0x88
   @calib26_register 0xE1
@@ -9,16 +9,17 @@ defmodule BMP280.BME280Comm do
   @ctrl_meas_register 0xF4
   @press_msb_register 0xF7
 
+  @oversampling_2x 2
+  @oversampling_16x 5
+
+  @normal_mode 3
+
   @spec set_oversampling(Transport.t()) :: :ok | {:error, any()}
   def set_oversampling(transport) do
-    # normal
-    mode = 3
-    # x2 oversampling
-    osrs_t = 2
-    # x16 oversampling
-    osrs_p = 5
-    # x16 oversampling
-    osrs_h = 5
+    mode = @normal_mode
+    osrs_t = @oversampling_2x
+    osrs_p = @oversampling_16x
+    osrs_h = @oversampling_16x
 
     with :ok <- Transport.write(transport, @ctrl_hum_register, <<osrs_h>>) do
       Transport.write(
@@ -29,7 +30,7 @@ defmodule BMP280.BME280Comm do
     end
   end
 
-  @spec read_calibration(Transport.t()) :: {:error, any} | {:ok, binary}
+  @spec read_calibration(Transport.t()) :: {:error, any} | {:ok, <<_::264>>}
   def read_calibration(transport) do
     with {:ok, first_part} <- Transport.read(transport, @calib00_register, 26),
          {:ok, second_part} <- Transport.read(transport, @calib26_register, 7) do
@@ -37,14 +38,8 @@ defmodule BMP280.BME280Comm do
     end
   end
 
-  @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, BME280Sensor.raw_samples()}
+  @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, <<_::64>>}
   def read_raw_samples(transport) do
-    case Transport.read(transport, @press_msb_register, 8) do
-      {:ok, <<pressure::20, _::4, temp::20, _::4, humidity::16>>} ->
-        {:ok, %{raw_pressure: pressure, raw_temperature: temp, raw_humidity: humidity}}
-
-      {:error, _reason} = error ->
-        error
-    end
+    Transport.read(transport, @press_msb_register, 8)
   end
 end

--- a/lib/bmp280/comm/bmp280_comm.ex
+++ b/lib/bmp280/comm/bmp280_comm.ex
@@ -1,20 +1,22 @@
 defmodule BMP280.BMP280Comm do
   @moduledoc false
 
-  alias BMP280.{BMP280Sensor, Transport}
+  alias BMP280.Transport
 
   @calib00_register 0x88
   @ctrl_meas_register 0xF4
   @press_msb_register 0xF7
 
+  @oversampling_2x 2
+  @oversampling_16x 5
+
+  @normal_mode 3
+
   @spec set_oversampling(Transport.t()) :: :ok | {:error, any()}
   def set_oversampling(transport) do
-    # normal
-    mode = 3
-    # x2 oversampling
-    osrs_t = 2
-    # x16 oversampling
-    osrs_p = 5
+    mode = @normal_mode
+    osrs_t = @oversampling_2x
+    osrs_p = @oversampling_16x
 
     Transport.write(
       transport,
@@ -23,19 +25,13 @@ defmodule BMP280.BMP280Comm do
     )
   end
 
-  @spec read_calibration(Transport.t()) :: {:error, any} | {:ok, binary}
+  @spec read_calibration(Transport.t()) :: {:error, any} | {:ok, <<_::192>>}
   def read_calibration(transport) do
     Transport.read(transport, @calib00_register, 24)
   end
 
-  @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, BMP280Sensor.raw_samples()}
+  @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, <<_::48>>}
   def read_raw_samples(transport) do
-    case Transport.read(transport, @press_msb_register, 6) do
-      {:ok, <<pressure::20, _::4, temp::20, _::4>>} ->
-        {:ok, %{raw_pressure: pressure, raw_temperature: temp}}
-
-      {:error, _reason} = error ->
-        error
-    end
+    Transport.read(transport, @press_msb_register, 6)
   end
 end

--- a/lib/bmp280/sensor/bme280_sensor.ex
+++ b/lib/bmp280/sensor/bme280_sensor.ex
@@ -5,17 +5,11 @@ defmodule BMP280.BME280Sensor do
 
   @behaviour BMP280.Sensor
 
-  @type raw_samples() :: %{
-          raw_pressure: non_neg_integer(),
-          raw_temperature: non_neg_integer(),
-          raw_humidity: non_neg_integer()
-        }
-
   @impl true
   def init(%{sensor_type: :bme280, transport: transport} = state) do
     with :ok <- BME280Comm.set_oversampling(transport),
          {:ok, calibration_binary} <- BME280Comm.read_calibration(transport),
-         calibration <- BME280Calibration.from_binary(calibration_binary),
+         calibration = BME280Calibration.from_binary(calibration_binary),
          do: %{state | calibration: calibration}
   end
 
@@ -27,11 +21,14 @@ defmodule BMP280.BME280Sensor do
     end
   end
 
-  @spec measurement_from_raw_samples(raw_samples(), BMP280.state()) :: BMP280.Measurement.t()
-  def measurement_from_raw_samples(raw, %{calibration: calibration, sea_level_pa: sea_level_pa}) do
-    temperature_c = BME280Calibration.raw_to_temperature(calibration, raw.raw_temperature)
-    pressure_pa = BME280Calibration.raw_to_pressure(calibration, temperature_c, raw.raw_pressure)
-    humidity_rh = BME280Calibration.raw_to_humidity(calibration, temperature_c, raw.raw_humidity)
+  @spec measurement_from_raw_samples(<<_::64>>, BMP280.state()) :: BMP280.Measurement.t()
+  def measurement_from_raw_samples(raw_samples, state) do
+    <<raw_pressure::20, _::4, raw_temperature::20, _::4, raw_humidity::16>> = raw_samples
+    %{calibration: calibration, sea_level_pa: sea_level_pa} = state
+
+    temperature_c = BME280Calibration.raw_to_temperature(calibration, raw_temperature)
+    pressure_pa = BME280Calibration.raw_to_pressure(calibration, temperature_c, raw_pressure)
+    humidity_rh = BME280Calibration.raw_to_humidity(calibration, temperature_c, raw_humidity)
 
     # Derived calculations
     altitude_m = Calc.pressure_to_altitude(pressure_pa, sea_level_pa)

--- a/lib/bmp280/sensor/bmp280_sensor.ex
+++ b/lib/bmp280/sensor/bmp280_sensor.ex
@@ -5,11 +5,6 @@ defmodule BMP280.BMP280Sensor do
 
   @behaviour BMP280.Sensor
 
-  @type raw_samples() :: %{
-          raw_pressure: non_neg_integer(),
-          raw_temperature: non_neg_integer()
-        }
-
   @impl true
   def init(%{sensor_type: :bmp280, transport: transport} = state) do
     with :ok <- BMP280Comm.set_oversampling(transport),
@@ -26,10 +21,13 @@ defmodule BMP280.BMP280Sensor do
     end
   end
 
-  @spec measurement_from_raw_samples(raw_samples(), BMP280.state()) :: BMP280.Measurement.t()
-  def measurement_from_raw_samples(raw, %{calibration: calibration, sea_level_pa: sea_level_pa}) do
-    temperature_c = BMP280Calibration.raw_to_temperature(calibration, raw.raw_temperature)
-    pressure_pa = BMP280Calibration.raw_to_pressure(calibration, temperature_c, raw.raw_pressure)
+  @spec measurement_from_raw_samples(<<_::48>>, BMP280.state()) :: BMP280.Measurement.t()
+  def measurement_from_raw_samples(raw_samples, state) do
+    <<raw_pressure::20, _::4, raw_temperature::20, _::4>> = raw_samples
+    %{calibration: calibration, sea_level_pa: sea_level_pa} = state
+
+    temperature_c = BMP280Calibration.raw_to_temperature(calibration, raw_temperature)
+    pressure_pa = BMP280Calibration.raw_to_pressure(calibration, temperature_c, raw_pressure)
 
     # Derived calculations
     altitude_m = Calc.pressure_to_altitude(pressure_pa, sea_level_pa)


### PR DESCRIPTION
This PR make our comm modules leaner. Currently, comm modules contain the logic to parse raw data, which is not the comm concern. Now the comm modules can focus on read and write operations.

I also did minor clean up in those modules.
