### PR TITLE
Fix references in the hexdocs

### DIFF
--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -30,20 +30,9 @@ defmodule BMP280 do
   @type options() :: [
           name: GenServer.name(),
           bus_name: String.t(),
-          bus_address: Transport.address(),
+          bus_address: 0x76 | 0x77,
           sea_level_pa: number()
         ]
-
-  @type state :: %{
-          calibration:
-            BMP280.BMP280Calibration.t()
-            | BMP280.BME280Calibration.t()
-            | BMP280.BME680Calibration.t(),
-          last_measurement: BMP280.Measurement.t(),
-          sea_level_pa: number(),
-          sensor_type: BMP280.sensor_type(),
-          transport: BMP280.Transport.t()
-        }
 
   @doc """
   Start a new GenServer for interacting with a BMP280
@@ -118,8 +107,7 @@ defmodule BMP280 do
 
   The bus address is likely going to be 0x77 (the default) or 0x76.
   """
-  @spec detect(String.t(), Transport.address()) ::
-          {:ok, sensor_type()} | {:error, any()}
+  @spec detect(String.t(), 0x76 | 0x77) :: {:ok, sensor_type()} | {:error, any()}
   def detect(bus_name, bus_address \\ @default_bmp280_bus_address) do
     with {:ok, transport} <- Transport.open(bus_name, bus_address) do
       Comm.sensor_type(transport)

--- a/lib/bmp280/sensor.ex
+++ b/lib/bmp280/sensor.ex
@@ -1,7 +1,18 @@
 defmodule BMP280.Sensor do
   @moduledoc false
 
-  @callback init(BMP280.state()) :: BMP280.state()
+  @type t :: %{
+          calibration:
+            BMP280.BMP280Calibration.t()
+            | BMP280.BME280Calibration.t()
+            | BMP280.BME680Calibration.t(),
+          last_measurement: BMP280.Measurement.t(),
+          sea_level_pa: number(),
+          sensor_type: BMP280.sensor_type(),
+          transport: BMP280.Transport.t()
+        }
 
-  @callback read(BMP280.state()) :: {:ok, BMP280.Measurement.t()} | {:error, any}
+  @callback init(BMP280.Sensor.t()) :: BMP280.Sensor.t()
+
+  @callback read(BMP280.Sensor.t()) :: {:ok, BMP280.Measurement.t()} | {:error, any}
 end

--- a/lib/bmp280/sensor/bme280_sensor.ex
+++ b/lib/bmp280/sensor/bme280_sensor.ex
@@ -21,7 +21,7 @@ defmodule BMP280.BME280Sensor do
     end
   end
 
-  @spec measurement_from_raw_samples(<<_::64>>, BMP280.state()) :: BMP280.Measurement.t()
+  @spec measurement_from_raw_samples(<<_::64>>, BMP280.Sensor.t()) :: BMP280.Measurement.t()
   def measurement_from_raw_samples(raw_samples, state) do
     <<raw_pressure::20, _::4, raw_temperature::20, _::4, raw_humidity::16>> = raw_samples
     %{calibration: calibration, sea_level_pa: sea_level_pa} = state

--- a/lib/bmp280/sensor/bme680_sensor.ex
+++ b/lib/bmp280/sensor/bme680_sensor.ex
@@ -50,7 +50,7 @@ defmodule BMP280.BME680Sensor do
     end
   end
 
-  @spec measurement_from_raw_samples(<<_::80>>, BMP280.state()) :: BMP280.Measurement.t()
+  @spec measurement_from_raw_samples(<<_::80>>, BMP280.Sensor.t()) :: BMP280.Measurement.t()
   def measurement_from_raw_samples(raw_samples, state) do
     <<raw_pressure::20, _::4, raw_temperature::20, _::4, raw_humidity::16, _::16>> = raw_samples
     <<_::64, raw_gas_resistance::10, _::2, raw_gas_range::4>> = raw_samples

--- a/lib/bmp280/sensor/bmp280_sensor.ex
+++ b/lib/bmp280/sensor/bmp280_sensor.ex
@@ -21,7 +21,7 @@ defmodule BMP280.BMP280Sensor do
     end
   end
 
-  @spec measurement_from_raw_samples(<<_::48>>, BMP280.state()) :: BMP280.Measurement.t()
+  @spec measurement_from_raw_samples(<<_::48>>, BMP280.Sensor.t()) :: BMP280.Measurement.t()
   def measurement_from_raw_samples(raw_samples, state) do
     <<raw_pressure::20, _::4, raw_temperature::20, _::4>> = raw_samples
     %{calibration: calibration, sea_level_pa: sea_level_pa} = state


### PR DESCRIPTION
Currently some types in the top-level `BMP280` modules are not accessible in the Hexdocs because they are private.