### PR TITLE
bmp180 support

### DIFF
--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -13,7 +13,7 @@ defmodule BMP280 do
 
   If the sensor is unknown, then number in the parts ID register is used.
   """
-  @type sensor_type() :: :bmp280 | :bme280 | :bme680 | 0..255
+  @type sensor_type() :: :bmp180 | :bmp280 | :bme280 | :bme680 | 0..255
 
   @moduledoc """
   Read temperature and pressure from a Bosch BM280, BME280, or BME680 sensor
@@ -209,6 +209,7 @@ defmodule BMP280 do
     end
   end
 
+  defp sensor_module(:bmp180), do: BMP280.BMP180Sensor
   defp sensor_module(:bmp280), do: BMP280.BMP280Sensor
   defp sensor_module(:bme280), do: BMP280.BME280Sensor
   defp sensor_module(:bme680), do: BMP280.BME680Sensor

--- a/lib/bmp280/calibration/bmp180_calibration.ex
+++ b/lib/bmp280/calibration/bmp180_calibration.ex
@@ -3,17 +3,17 @@ defmodule BMP280.BMP180Calibration do
 
   @type t() :: %{
           type: :bmp180,
-          ac1: integer,
-          ac2: integer,
-          ac3: integer,
-          ac4: integer,
-          ac5: integer,
-          ac6: integer,
-          b1: integer,
-          b2: integer,
-          mb: integer,
-          mc: integer,
-          md: integer
+          ac1: integer(),
+          ac2: integer(),
+          ac3: integer(),
+          ac4: char(),
+          ac5: char(),
+          ac6: char(),
+          b1: integer(),
+          b2: integer(),
+          mb: integer(),
+          mc: integer(),
+          md: integer()
         }
 
   @two_2 :math.pow(2, 2)
@@ -25,24 +25,25 @@ defmodule BMP280.BMP180Calibration do
   @two_15 :math.pow(2, 15)
   @two_16 :math.pow(2, 16)
 
-  @spec from_binary(binary) :: t()
+  @spec from_binary(<<_::176>>) :: t()
   def from_binary(
-        <<ac1::16, ac2::16, ac3::16, ac4::16, ac5::16, ac6::16, b1::16, b2::16, mb::16, mc::16,
-          md::16>>
+        <<ac1::big-signed-16, ac2::big-signed-16, ac3::big-signed-16, ac4::big-unsigned-16,
+          ac5::big-unsigned-16, ac6::big-unsigned-16, b1::big-signed-16, b2::big-signed-16,
+          mb::big-signed-16, mc::big-signed-16, md::big-signed-16>>
       ) do
     %{
       type: :bmp180,
-      ac1: swap(ac1),
-      ac2: swap(ac2),
-      ac3: swap(ac3),
-      ac4: swap_unsigned(ac4),
-      ac5: swap_unsigned(ac5),
-      ac6: swap_unsigned(ac6),
-      b1: swap(b1),
-      b2: swap(b2),
-      mb: swap(mb),
-      mc: swap(mc),
-      md: swap(md)
+      ac1: ac1,
+      ac2: ac2,
+      ac3: ac3,
+      ac4: ac4,
+      ac5: ac5,
+      ac6: ac6,
+      b1: b1,
+      b2: b2,
+      mb: mb,
+      mc: mc,
+      md: md
     }
   end
 
@@ -76,16 +77,4 @@ defmodule BMP280.BMP180Calibration do
 
   defp p(b7, b4) when b7 < 0x80000000, do: b7 * 2 / b4
   defp p(b7, b4), do: b7 / b4 * 2
-
-  defp swap(data) do
-    <<a::8, b::8>> = <<data::16>>
-    <<data::little-signed-16>> = <<b::8, a::8>>
-    data
-  end
-
-  defp swap_unsigned(data) do
-    <<a::8, b::8>> = <<data::16>>
-    <<data::little-unsigned-16>> = <<b::8, a::8>>
-    data
-  end
 end

--- a/lib/bmp280/calibration/bmp180_calibration.ex
+++ b/lib/bmp280/calibration/bmp180_calibration.ex
@@ -1,0 +1,82 @@
+defmodule BMP280.BMP180Calibration do
+  @moduledoc false
+
+  @type t() :: %{
+          type: :bmp180,
+          ac1: integer,
+          ac2: integer,
+          ac3: integer,
+          ac4: integer,
+          ac5: integer,
+          ac6: integer,
+          b1: integer,
+          b2: integer,
+          mb: integer,
+          mc: integer,
+          md: integer
+        }
+
+  @two_2 :math.pow(2, 2)
+  @two_4 :math.pow(2, 4)
+  @two_8 :math.pow(2, 8)
+  @two_11 :math.pow(2, 11)
+  @two_12 :math.pow(2, 12)
+  @two_13 :math.pow(2, 13)
+  @two_15 :math.pow(2, 15)
+  @two_16 :math.pow(2, 16)
+
+  @spec from_binary(binary) :: t()
+  def from_binary(
+        <<ac1::little-16, ac2::little-16, ac3::little-16, ac4::little-unsigned-16,
+          ac5::little-unsigned-16, ac6::little-unsigned-16, b1::little-16, b2::little-16,
+          mb::little-16, mc::little-16, md::little-16>>
+      ) do
+    %{
+      type: :bmp180,
+      ac1: s(ac1),
+      ac2: s(ac2),
+      ac3: s(ac3),
+      ac4: s(ac4),
+      ac5: s(ac5),
+      ac6: s(ac6),
+      b1: s(b1),
+      b2: s(b2),
+      mb: s(mb),
+      mc: s(mc),
+      md: s(md)
+    }
+  end
+
+  @spec raw_to_temperature(t(), integer()) :: float()
+  def raw_to_temperature(cal, raw_temp) do
+    x1 = (raw_temp - cal.ac6) * cal.ac5 / @two_15
+    x2 = cal.mc * @two_11 / (x1 + cal.md)
+    b5 = x1 + x2
+    (b5 + 8) / @two_4 / 10
+  end
+
+  @spec raw_to_pressure(t(), number(), number()) :: float()
+  def raw_to_pressure(cal, temp, raw_pressure) do
+    b5 = temp * 10 * @two_4 - 8
+    b6 = b5 - 4000
+    x1 = cal.b2 * (b6 * b6) / @two_12 / @two_11
+    x2 = cal.ac2 * b6 / @two_11
+    x3 = x1 + x2
+    b3 = (cal.ac1 * 4 + x3 + 2) / 4
+    x1 = cal.ac3 * b6 / @two_13
+    x2 = cal.b1 * (b6 * b6 / @two_12) / @two_16
+    x3 = (x1 + x2 + 2) / @two_2
+    b4 = cal.ac4 * (x3 + 32768) / @two_15
+    b7 = (raw_pressure - b3) * 50000
+    p = p(b7, b4)
+    x1 = p / @two_8 * (p / @two_8)
+    x1 = x1 * 3038 / @two_16
+    x2 = -7357 * p / @two_16
+    p + (x1 + x2 + 3791) / @two_4
+  end
+
+  defp p(b7, b4) when b7 < 0x80000000, do: b7 * 2 / b4
+  defp p(b7, b4), do: b7 / b4 * 2
+
+  defp s(data), do: data
+end

--- a/lib/bmp280/calibration/bmp180_calibration.ex
+++ b/lib/bmp280/calibration/bmp180_calibration.ex
@@ -3,17 +3,17 @@ defmodule BMP280.BMP180Calibration do
 
   @type t() :: %{
           type: :bmp180,
-          ac1: integer(),
-          ac2: integer(),
-          ac3: integer(),
-          ac4: char(),
-          ac5: char(),
-          ac6: char(),
-          b1: integer(),
-          b2: integer(),
-          mb: integer(),
-          mc: integer(),
-          md: integer()
+          ac1: integer,
+          ac2: integer,
+          ac3: integer,
+          ac4: char,
+          ac5: char,
+          ac6: char,
+          b1: integer,
+          b2: integer,
+          mb: integer,
+          mc: integer,
+          md: integer
         }
 
   @two_2 :math.pow(2, 2)

--- a/lib/bmp280/calibration/bmp180_calibration.ex
+++ b/lib/bmp280/calibration/bmp180_calibration.ex
@@ -32,17 +32,17 @@ defmodule BMP280.BMP180Calibration do
       ) do
     %{
       type: :bmp180,
-      ac1: s(ac1),
-      ac2: s(ac2),
-      ac3: s(ac3),
-      ac4: su(ac4),
-      ac5: su(ac5),
-      ac6: su(ac6),
-      b1: s(b1),
-      b2: s(b2),
-      mb: s(mb),
-      mc: s(mc),
-      md: s(md)
+      ac1: swap(ac1),
+      ac2: swap(ac2),
+      ac3: swap(ac3),
+      ac4: swap_unsigned(ac4),
+      ac5: swap_unsigned(ac5),
+      ac6: swap_unsigned(ac6),
+      b1: swap(b1),
+      b2: swap(b2),
+      mb: swap(mb),
+      mc: swap(mc),
+      md: swap(md)
     }
   end
 
@@ -77,13 +77,13 @@ defmodule BMP280.BMP180Calibration do
   defp p(b7, b4) when b7 < 0x80000000, do: b7 * 2 / b4
   defp p(b7, b4), do: b7 / b4 * 2
 
-  defp s(data) do
+  defp swap(data) do
     <<a::8, b::8>> = <<data::16>>
     <<data::little-signed-16>> = <<b::8, a::8>>
     data
   end
 
-  defp su(data) do
+  defp swap_unsigned(data) do
     <<a::8, b::8>> = <<data::16>>
     <<data::little-unsigned-16>> = <<b::8, a::8>>
     data

--- a/lib/bmp280/comm.ex
+++ b/lib/bmp280/comm.ex
@@ -14,6 +14,7 @@ defmodule BMP280.Comm do
     end
   end
 
+  defp id_to_type(0x55), do: :bmp180
   defp id_to_type(0x58), do: :bmp280
   defp id_to_type(0x60), do: :bme280
   defp id_to_type(0x61), do: :bme680

--- a/lib/bmp280/comm/bmp180_comm.ex
+++ b/lib/bmp280/comm/bmp180_comm.ex
@@ -1,0 +1,40 @@
+defmodule BMP280.BMP180Comm do
+  @moduledoc false
+
+  alias BMP280.Transport
+
+  @calib00_register 0xAA
+  @ctrl_meas_register 0xF4
+  @data_msb_register 0xF6
+
+  @read_temp <<0xF4, 0x2E>>
+  @read_pressure <<0xF4, 0x34>>
+
+  @spec set_temperature_reading(Transport.t()) :: :ok | {:error, any()}
+  def set_temperature_reading(transport) do
+    Transport.write(
+      transport,
+      @ctrl_meas_register,
+      @read_temp
+    )
+  end
+
+  @spec set_pressure_reading(Transport.t()) :: :ok | {:error, any()}
+  def set_pressure_reading(transport) do
+    Transport.write(
+      transport,
+      @ctrl_meas_register,
+      @read_pressure
+    )
+  end
+
+  @spec read_calibration(Transport.t()) :: {:error, any} | {:ok, <<_::176>>}
+  def read_calibration(transport) do
+    Transport.read(transport, @calib00_register, 22)
+  end
+
+  @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, <<_::16>>}
+  def read_raw_samples(transport) do
+    Transport.read(transport, @data_msb_register, 2)
+  end
+end

--- a/lib/bmp280/comm/bmp180_comm.ex
+++ b/lib/bmp280/comm/bmp180_comm.ex
@@ -3,12 +3,15 @@ defmodule BMP280.BMP180Comm do
 
   alias BMP280.Transport
 
-  @calib00_register 0xAA
+  @calib_register 0xAA
+  @calib_size 22
   @ctrl_meas_register 0xF4
-  @data_msb_register 0xF6
 
-  @read_temp 0x2E
-  @read_pressure 0x34
+  @data_msb_register 0xF6
+  @data_size 3
+
+  @read_temp <<0x2E::8>>
+  @read_pressure <<0x34::8>>
 
   @spec set_temperature_reading(Transport.t()) :: :ok | {:error, any()}
   def set_temperature_reading(transport) do
@@ -30,11 +33,11 @@ defmodule BMP280.BMP180Comm do
 
   @spec read_calibration(Transport.t()) :: {:error, any} | {:ok, <<_::176>>}
   def read_calibration(transport) do
-    Transport.read(transport, @calib00_register, 22)
+    Transport.read(transport, @calib_register, @calib_size)
   end
 
-  @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, <<_::16>>}
+  @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, <<_::24>>}
   def read_raw_samples(transport) do
-    Transport.read(transport, @data_msb_register, 3)
+    Transport.read(transport, @data_msb_register, @data_size)
   end
 end

--- a/lib/bmp280/comm/bmp180_comm.ex
+++ b/lib/bmp280/comm/bmp180_comm.ex
@@ -7,8 +7,8 @@ defmodule BMP280.BMP180Comm do
   @ctrl_meas_register 0xF4
   @data_msb_register 0xF6
 
-  @read_temp <<0xF4, 0x2E>>
-  @read_pressure <<0xF4, 0x34>>
+  @read_temp 0x2E
+  @read_pressure 0x34
 
   @spec set_temperature_reading(Transport.t()) :: :ok | {:error, any()}
   def set_temperature_reading(transport) do
@@ -35,6 +35,6 @@ defmodule BMP280.BMP180Comm do
 
   @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, <<_::16>>}
   def read_raw_samples(transport) do
-    Transport.read(transport, @data_msb_register, 2)
+   Transport.read(transport, @data_msb_register, 3)
   end
 end

--- a/lib/bmp280/comm/bmp180_comm.ex
+++ b/lib/bmp280/comm/bmp180_comm.ex
@@ -35,6 +35,6 @@ defmodule BMP280.BMP180Comm do
 
   @spec read_raw_samples(Transport.t()) :: {:error, any} | {:ok, <<_::16>>}
   def read_raw_samples(transport) do
-   Transport.read(transport, @data_msb_register, 3)
+    Transport.read(transport, @data_msb_register, 3)
   end
 end

--- a/lib/bmp280/sensor.ex
+++ b/lib/bmp280/sensor.ex
@@ -3,7 +3,8 @@ defmodule BMP280.Sensor do
 
   @type t :: %{
           calibration:
-            BMP280.BMP280Calibration.t()
+            BMP280.BMP180Calibration.t()
+            | BMP280.BMP280Calibration.t()
             | BMP280.BME280Calibration.t()
             | BMP280.BME680Calibration.t(),
           last_measurement: BMP280.Measurement.t(),

--- a/lib/bmp280/sensor/bmp180_sensor.ex
+++ b/lib/bmp280/sensor/bmp180_sensor.ex
@@ -24,26 +24,22 @@ defmodule BMP280.BMP180Sensor do
   @spec measurement_from_raw_samples(<<_::16>>, <<_::16>>, BMP180.Sensor.t()) ::
           BMP180.Measurement.t()
   def measurement_from_raw_samples(raw_temperature, raw_pressure, state) do
-    <<raw_temperature::16>> = s(raw_temperature)
-    <<raw_pressure::16>> = s(raw_pressure)
     %{calibration: calibration, sea_level_pa: sea_level_pa} = state
 
     temperature_c = BMP180Calibration.raw_to_temperature(calibration, raw_temperature)
     pressure_pa = BMP180Calibration.raw_to_pressure(calibration, temperature_c, raw_pressure)
 
     # Derived calculations
-    # altitude_m = Calc.pressure_to_altitude(pressure_pa, sea_level_pa)
+    altitude_m = Calc.pressure_to_altitude(pressure_pa, sea_level_pa)
 
     %Measurement{
       temperature_c: temperature_c,
       pressure_pa: pressure_pa,
-      altitude_m: :unknown,
+      altitude_m: altitude_m,
       humidity_rh: :unknown,
       dew_point_c: :unknown,
       gas_resistance_ohms: :unknown,
       timestamp_ms: System.monotonic_time(:millisecond)
     }
   end
-
-  defp s(data), do: data
 end

--- a/lib/bmp280/sensor/bmp180_sensor.ex
+++ b/lib/bmp280/sensor/bmp180_sensor.ex
@@ -14,17 +14,17 @@ defmodule BMP280.BMP180Sensor do
 
   @impl true
   def read(%{transport: transport} = state) do
-    BMP180Comm.set_temperature_reading(transport)
-    :timer.sleep(10)
+    :ok = BMP180Comm.set_temperature_reading(transport)
+    Process.sleep(10)
     {:ok, raw_temperature} = BMP180Comm.read_raw_samples(transport)
-    BMP180Comm.set_pressure_reading(transport)
-    :timer.sleep(10)
+    :ok = BMP180Comm.set_pressure_reading(transport)
+    Process.sleep(10)
     {:ok, raw_pressure} = BMP180Comm.read_raw_samples(transport)
     {:ok, measurement_from_raw_samples(raw_temperature, raw_pressure, state)}
   end
 
-  @spec measurement_from_raw_samples(<<_::16>>, <<_::16>>, BMP180.Sensor.t()) ::
-          BMP180.Measurement.t()
+  @spec measurement_from_raw_samples(<<_::24>>, <<_::24>>, BMP280.Sensor.t()) ::
+          BMP280.Measurement.t()
   def measurement_from_raw_samples(raw_temperature, raw_pressure, state) do
     %{calibration: calibration, sea_level_pa: sea_level_pa} = state
 

--- a/lib/bmp280/sensor/bmp180_sensor.ex
+++ b/lib/bmp280/sensor/bmp180_sensor.ex
@@ -15,8 +15,10 @@ defmodule BMP280.BMP180Sensor do
   @impl true
   def read(%{transport: transport} = state) do
     BMP180Comm.set_temperature_reading(transport)
+    :timer.sleep(10)
     {:ok, raw_temperature} = BMP180Comm.read_raw_samples(transport)
     BMP180Comm.set_pressure_reading(transport)
+    :timer.sleep(10)
     {:ok, raw_pressure} = BMP180Comm.read_raw_samples(transport)
     {:ok, measurement_from_raw_samples(raw_temperature, raw_pressure, state)}
   end

--- a/lib/bmp280/sensor/bmp180_sensor.ex
+++ b/lib/bmp280/sensor/bmp180_sensor.ex
@@ -1,0 +1,49 @@
+defmodule BMP280.BMP180Sensor do
+  @moduledoc false
+
+  alias BMP280.{BMP180Calibration, BMP180Comm, Calc, Measurement}
+
+  @behaviour BMP280.Sensor
+
+  @impl true
+  def init(%{sensor_type: :bmp180, transport: transport} = state) do
+    with {:ok, calibration_binary} <- BMP180Comm.read_calibration(transport),
+         calibration <- BMP180Calibration.from_binary(calibration_binary),
+         do: %{state | calibration: calibration}
+  end
+
+  @impl true
+  def read(%{transport: transport} = state) do
+    BMP180Comm.set_temperature_reading(transport)
+    {:ok, raw_temperature} = BMP180Comm.read_raw_samples(transport)
+    BMP180Comm.set_pressure_reading(transport)
+    {:ok, raw_pressure} = BMP180Comm.read_raw_samples(transport)
+    {:ok, measurement_from_raw_samples(raw_temperature, raw_pressure, state)}
+  end
+
+  @spec measurement_from_raw_samples(<<_::16>>, <<_::16>>, BMP180.Sensor.t()) ::
+          BMP180.Measurement.t()
+  def measurement_from_raw_samples(raw_temperature, raw_pressure, state) do
+    <<raw_temperature::16>> = s(raw_temperature)
+    <<raw_pressure::16>> = s(raw_pressure)
+    %{calibration: calibration, sea_level_pa: sea_level_pa} = state
+
+    temperature_c = BMP180Calibration.raw_to_temperature(calibration, raw_temperature)
+    pressure_pa = BMP180Calibration.raw_to_pressure(calibration, temperature_c, raw_pressure)
+
+    # Derived calculations
+    # altitude_m = Calc.pressure_to_altitude(pressure_pa, sea_level_pa)
+
+    %Measurement{
+      temperature_c: temperature_c,
+      pressure_pa: pressure_pa,
+      altitude_m: :unknown,
+      humidity_rh: :unknown,
+      dew_point_c: :unknown,
+      gas_resistance_ohms: :unknown,
+      timestamp_ms: System.monotonic_time(:millisecond)
+    }
+  end
+
+  defp s(data), do: data
+end

--- a/test/bmp280/calibration/bmp180_calibration_test.exs
+++ b/test/bmp280/calibration/bmp180_calibration_test.exs
@@ -1,0 +1,49 @@
+defmodule BMP280.BMP180CalibrationTest do
+  use ExUnit.Case
+  # alias BMP280.BMP180Calibration
+  doctest BMP280.BMP180Calibration
+
+  test "parse bme280 1 calibration" do
+    raw_calibration =
+      <<25, 38, 251, 185, 200, 200, 133, 213, 100, 76, 63, 129, 25, 115, 0, 40, 128, 0, 209, 246,
+        9, 104>>
+
+    # assert BMP180Calibration.from_binary(raw_calibration) ==
+    assert from_binary(raw_calibration) ==
+             %{
+               type: :bmp180,
+               ac1: 408,
+               ac2: -72,
+               ac3: -14383,
+               ac4: 32741,
+               ac5: 32757,
+               ac6: 23153,
+               b1: 6190,
+               b2: 4,
+               mb: -32768,
+               mc: -8711,
+               md: 2868
+             }
+  end
+
+  def from_binary(
+        <<ac1::little-16, ac2::little-16, ac3::little-16, ac4::little-unsigned-16,
+          ac5::little-unsigned-16, ac6::little-unsigned-16, b1::little-16, b2::little-16,
+          mb::little-16, mc::little-16, md::little-16>>
+      ) do
+    %{
+      type: :bmp180,
+      ac1: ac1,
+      ac2: ac2,
+      ac3: ac3,
+      ac4: ac4,
+      ac5: ac5,
+      ac6: ac6,
+      b1: b1,
+      b2: b2,
+      mb: mb,
+      mc: mc,
+      md: md
+    }
+  end
+end

--- a/test/bmp280/calibration/bmp180_calibration_test.exs
+++ b/test/bmp280/calibration/bmp180_calibration_test.exs
@@ -1,6 +1,6 @@
 defmodule BMP280.BMP180CalibrationTest do
   use ExUnit.Case
-  # alias BMP280.BMP180Calibration
+  alias BMP280.BMP180Calibration
   doctest BMP280.BMP180Calibration
 
   test "parse bme280 1 calibration" do
@@ -8,42 +8,20 @@ defmodule BMP280.BMP180CalibrationTest do
       <<25, 38, 251, 185, 200, 200, 133, 213, 100, 76, 63, 129, 25, 115, 0, 40, 128, 0, 209, 246,
         9, 104>>
 
-    # assert BMP180Calibration.from_binary(raw_calibration) ==
-    assert from_binary(raw_calibration) ==
+    assert BMP180Calibration.from_binary(raw_calibration) ==
              %{
-               type: :bmp180,
-               ac1: 408,
-               ac2: -72,
-               ac3: -14383,
-               ac4: 32741,
-               ac5: 32757,
-               ac6: 23153,
-               b1: 6190,
-               b2: 4,
+               ac1: 6438,
+               ac2: -1095,
+               ac3: -14136,
+               ac4: 34261,
+               ac5: 25676,
+               ac6: 16257,
+               b1: 6515,
+               b2: 40,
                mb: -32768,
-               mc: -8711,
-               md: 2868
+               mc: -11786,
+               md: 2408,
+               type: :bmp180
              }
-  end
-
-  def from_binary(
-        <<ac1::little-16, ac2::little-16, ac3::little-16, ac4::little-unsigned-16,
-          ac5::little-unsigned-16, ac6::little-unsigned-16, b1::little-16, b2::little-16,
-          mb::little-16, mc::little-16, md::little-16>>
-      ) do
-    %{
-      type: :bmp180,
-      ac1: ac1,
-      ac2: ac2,
-      ac3: ac3,
-      ac4: ac4,
-      ac5: ac5,
-      ac6: ac6,
-      b1: b1,
-      b2: b2,
-      mb: mb,
-      mc: mc,
-      md: md
-    }
   end
 end

--- a/test/bmp280/sensor/bmp180_sensor_test.exs
+++ b/test/bmp280/sensor/bmp180_sensor_test.exs
@@ -1,0 +1,31 @@
+defmodule BMP280.BME180SensorTest do
+  use ExUnit.Case
+  alias BMP280.BMP180Sensor
+  doctest BMP280.BMP180Sensor
+
+  @bme180_calibration1 %{
+    type: :bmp180,
+    ac1: 408,
+    ac2: -72,
+    ac3: -14383,
+    ac4: 32741,
+    ac5: 32757,
+    ac6: 23153,
+    b1: 6190,
+    b2: 4,
+    mb: -32768,
+    mc: -8711,
+    md: 2868
+  }
+
+  test "bme180 1 calculations" do
+    raw_temperature = <<108, 250>>
+    raw_pressure = <<93, 35>>
+    state = %{calibration: @bme180_calibration1, sea_level_pa: 100_000}
+
+    measurement = BMP180Sensor.measurement_from_raw_samples(raw_temperature, raw_pressure, state)
+
+    assert_in_delta 15.0, measurement.temperature_c, 0.05
+    assert_in_delta 69964, measurement.pressure_pa, 5
+  end
+end

--- a/test/bmp280/sensor/bmp180_sensor_test.exs
+++ b/test/bmp280/sensor/bmp180_sensor_test.exs
@@ -18,14 +18,40 @@ defmodule BMP280.BME180SensorTest do
     md: 2868
   }
 
+  @bme180_calibration2 %{
+               ac1: 6438,
+               ac2: -1095,
+               ac3: -14136,
+               ac4: 34261,
+               ac5: 25676,
+               ac6: 16257,
+               b1: 6515,
+               b2: 40,
+               mb: -32768,
+               mc: -11786,
+               md: 2408,
+               type: :bmp180
+             }
+
   test "bme180 1 calculations" do
-    raw_temperature = <<108, 250>>
-    raw_pressure = <<93, 35>>
+    raw_temperature = <<108, 250, 0>>
+    raw_pressure = <<93, 35, 0>>
     state = %{calibration: @bme180_calibration1, sea_level_pa: 100_000}
 
     measurement = BMP180Sensor.measurement_from_raw_samples(raw_temperature, raw_pressure, state)
 
     assert_in_delta 15.0, measurement.temperature_c, 0.05
     assert_in_delta 69964, measurement.pressure_pa, 5
+  end
+
+  test "bme180 2 calculations" do
+    raw_temperature = <<95, 16, 0>>
+    raw_pressure = <<161, 135, 0>>
+    state = %{calibration: @bme180_calibration2, sea_level_pa: 100_000}
+
+    measurement = BMP180Sensor.measurement_from_raw_samples(raw_temperature, raw_pressure, state)
+
+    assert_in_delta 22.35, measurement.temperature_c, 0.05
+    assert_in_delta 101132.0, measurement.pressure_pa, 0.5
   end
 end

--- a/test/bmp280/sensor/bmp180_sensor_test.exs
+++ b/test/bmp280/sensor/bmp180_sensor_test.exs
@@ -19,19 +19,19 @@ defmodule BMP280.BME180SensorTest do
   }
 
   @bme180_calibration2 %{
-               ac1: 6438,
-               ac2: -1095,
-               ac3: -14136,
-               ac4: 34261,
-               ac5: 25676,
-               ac6: 16257,
-               b1: 6515,
-               b2: 40,
-               mb: -32768,
-               mc: -11786,
-               md: 2408,
-               type: :bmp180
-             }
+    ac1: 6438,
+    ac2: -1095,
+    ac3: -14136,
+    ac4: 34261,
+    ac5: 25676,
+    ac6: 16257,
+    b1: 6515,
+    b2: 40,
+    mb: -32768,
+    mc: -11786,
+    md: 2408,
+    type: :bmp180
+  }
 
   test "bme180 1 calculations" do
     raw_temperature = <<108, 250, 0>>
@@ -52,6 +52,6 @@ defmodule BMP280.BME180SensorTest do
     measurement = BMP180Sensor.measurement_from_raw_samples(raw_temperature, raw_pressure, state)
 
     assert_in_delta 22.35, measurement.temperature_c, 0.05
-    assert_in_delta 101132.0, measurement.pressure_pa, 0.5
+    assert_in_delta 101_132.0, measurement.pressure_pa, 0.5
   end
 end


### PR DESCRIPTION
example:
```
iex(1)> {:ok, bmp} = BMP280.start_link([])
{:ok, #PID<0.1167.0>}
iex(2)> BMP280.measure(bmp)
{:ok,
 %BMP280.Measurement{
   altitude_m: -94.79376738473972,
   dew_point_c: :unknown,
   gas_resistance_ohms: :unknown,
   humidity_rh: :unknown,
   pressure_pa: 101128.83542212451,
   temperature_c: 22.151404717757252,
   timestamp_ms: 36162
 }}
iex(3)>
```
