### PR TITLE
Handle dew point calculations with rh = 0

### DIFF
--- a/lib/bmp280/calc.ex
+++ b/lib/bmp280/calc.ex
@@ -30,4 +30,15 @@ defmodule BMP280.Calc do
 
     243.04 * (log_rh + 17.625 * t / (243.04 + t)) / (17.625 - log_rh - 17.625 * t / (243.04 + t))
   end
+
+  def dew_point(_humidity_rh, _temperature_c) do
+    # Handle out-of-range inputs. This only happens under extreme conditions.
+    # As for what to return, there's nothing obviously great. According to the
+    # Internets, the lowest recorded humidity was in Iran and had a dew point
+    # of -33.2. I've observed dew points in the -30s being returned from above.
+    # The logic for returning -40 is that it's both lower than what was
+    # observed and somewhat special since it's the Celsius/Fahrenheit crossover
+    # point.
+    -40
+  end
 end

--- a/test/bmp280/calc_test.exs
+++ b/test/bmp280/calc_test.exs
@@ -15,4 +15,8 @@ defmodule BMP280.CalcTest do
   test "dew point calculation" do
     assert_in_delta 14.87, Calc.dew_point(64, 22), 0.01
   end
+
+  test "dew point calculation doesn't crash" do
+    assert Calc.dew_point(0, 30) == -40
+  end
 end


### PR DESCRIPTION
It's possible for the sensor to return a relative humidity of 0. This
breaks the dew point calculation and raises an exception. This is
undesirable since even though the dew point and relative humidity aren't
right, other values are still useful.
