### PR TITLE
Refactor Sensor interface functions - simple

### DIFF
--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -2,7 +2,7 @@ defmodule BMP280 do
   use GenServer
   require Logger
 
-  alias BMP280.{Calc, Comm, Measurement, Transport}
+  alias BMP280.{Calc, Comm, Measurement, Sensor, Transport}
 
   @sea_level_pa 100_000
   @default_bmp280_bus_address 0x77
@@ -118,6 +118,7 @@ defmodule BMP280 do
   def init(args) do
     bus_name = Keyword.get(args, :bus_name, "i2c-1")
     bus_address = Keyword.get(args, :bus_address, @default_bmp280_bus_address)
+    sea_level_pa = Keyword.get(args, :sea_level_pa, @sea_level_pa)
 
     Logger.info(
       "[BMP280] Starting on bus #{bus_name} at address #{inspect(bus_address, base: :hex)}"
@@ -125,13 +126,8 @@ defmodule BMP280 do
 
     with {:ok, transport} <- Transport.open(bus_name, bus_address),
          {:ok, sensor_type} <- Comm.sensor_type(transport) do
-      state = %{
-        transport: transport,
-        calibration: nil,
-        sea_level_pa: Keyword.get(args, :sea_level_pa, @sea_level_pa),
-        sensor_type: sensor_type,
-        last_measurement: nil
-      }
+      state =
+        Sensor.new(transport: transport, sea_level_pa: sea_level_pa, sensor_type: sensor_type)
 
       {:ok, state, {:continue, :init_sensor}}
     else
@@ -146,7 +142,7 @@ defmodule BMP280 do
 
     new_state =
       state
-      |> init_sensor()
+      |> Sensor.init()
       |> read_and_put_new_measurement()
 
     schedule_measurement()
@@ -190,16 +186,8 @@ defmodule BMP280 do
     Process.send_after(self(), :schedule_measurement, @polling_interval)
   end
 
-  defp init_sensor(state) do
-    state.sensor_type |> sensor_module() |> apply(:init, [state])
-  end
-
-  defp read_sensor(state) do
-    state.sensor_type |> sensor_module() |> apply(:read, [state])
-  end
-
   defp read_and_put_new_measurement(state) do
-    case read_sensor(state) do
+    case Sensor.read(state) do
       {:ok, measurement} ->
         %{state | last_measurement: measurement}
 
@@ -208,9 +196,4 @@ defmodule BMP280 do
         state
     end
   end
-
-  defp sensor_module(:bmp180), do: BMP280.BMP180Sensor
-  defp sensor_module(:bmp280), do: BMP280.BMP280Sensor
-  defp sensor_module(:bme280), do: BMP280.BME280Sensor
-  defp sensor_module(:bme680), do: BMP280.BME680Sensor
 end

--- a/lib/bmp280/sensor.ex
+++ b/lib/bmp280/sensor.ex
@@ -1,6 +1,8 @@
 defmodule BMP280.Sensor do
   @moduledoc false
 
+  defstruct ~w[calibration last_measurement sea_level_pa sensor_type transport]a
+
   @type t :: %{
           calibration:
             BMP280.BMP180Calibration.t()
@@ -16,4 +18,21 @@ defmodule BMP280.Sensor do
   @callback init(BMP280.Sensor.t()) :: BMP280.Sensor.t()
 
   @callback read(BMP280.Sensor.t()) :: {:ok, BMP280.Measurement.t()} | {:error, any}
+
+  def new(opts) do
+    %__MODULE__{
+      transport: Access.fetch!(opts, :transport),
+      sea_level_pa: Access.fetch!(opts, :sea_level_pa),
+      sensor_type: Access.fetch!(opts, :sensor_type)
+    }
+  end
+
+  def init(state), do: sensor_mod(state.sensor_type).init(state)
+
+  def read(state), do: sensor_mod(state.sensor_type).read(state)
+
+  defp sensor_mod(sensor_type) do
+    sensor_type = sensor_type |> Atom.to_string() |> String.upcase()
+    String.to_existing_atom("Elixir.BMP280.#{sensor_type}Sensor")
+  end
 end


### PR DESCRIPTION
This is a minor refactoring in the top-level `BMP280` module. It reduces a bit of noise about sensor types by introducing `BMP280.Sensor` functions as a common interface.

