### PR TITLE
Refactor Sensor interface functions - protocol

### DIFF
--- a/lib/bmp280.ex
+++ b/lib/bmp280.ex
@@ -128,12 +128,12 @@ defmodule BMP280 do
          {:ok, sensor_type} <- Comm.sensor_type(transport) do
       state = %{
         last_measurement: nil,
+        sensor_type: sensor_type,
         sensor:
           struct(
             sensor_module(sensor_type),
             calibration: nil,
             sea_level_pa: sea_level_pa,
-            sensor_type: sensor_type,
             transport: transport
           )
       }
@@ -147,7 +147,7 @@ defmodule BMP280 do
 
   @impl GenServer
   def handle_continue(:init_sensor, state) do
-    Logger.info("[BMP280] Initializing sensor type #{state.sensor.sensor_type}")
+    Logger.info("[BMP280] Initializing sensor type #{state.sensor_type}")
 
     new_state =
       state
@@ -169,7 +169,7 @@ defmodule BMP280 do
   end
 
   def handle_call(:sensor_type, _from, state) do
-    {:reply, state.sensor.sensor_type, state}
+    {:reply, state.sensor_type, state}
   end
 
   def handle_call({:update_sea_level, new_estimate}, _from, state) do

--- a/lib/bmp280/sensor.ex
+++ b/lib/bmp280/sensor.ex
@@ -1,19 +1,20 @@
-defmodule BMP280.Sensor do
-  @moduledoc false
-
+defprotocol BMP280.Sensor do
   @type t :: %{
           calibration:
             BMP280.BMP180Calibration.t()
             | BMP280.BMP280Calibration.t()
             | BMP280.BME280Calibration.t()
             | BMP280.BME680Calibration.t(),
-          last_measurement: BMP280.Measurement.t(),
           sea_level_pa: number(),
           sensor_type: BMP280.sensor_type(),
           transport: BMP280.Transport.t()
         }
 
-  @callback init(BMP280.Sensor.t()) :: BMP280.Sensor.t()
+  @doc "Initializes a sensor"
+  @spec init(keyword() | map()) :: t()
+  def init(state)
 
-  @callback read(BMP280.Sensor.t()) :: {:ok, BMP280.Measurement.t()} | {:error, any}
+  @doc "Reads one measurement from a sensor"
+  @spec read(t()) :: {:ok, BMP280.Measurement.t()} | {:error, any()}
+  def read(state)
 end

--- a/lib/bmp280/sensor.ex
+++ b/lib/bmp280/sensor.ex
@@ -6,7 +6,6 @@ defprotocol BMP280.Sensor do
             | BMP280.BME280Calibration.t()
             | BMP280.BME680Calibration.t(),
           sea_level_pa: number(),
-          sensor_type: BMP280.sensor_type(),
           transport: BMP280.Transport.t()
         }
 

--- a/lib/bmp280/sensor/bme280_sensor.ex
+++ b/lib/bmp280/sensor/bme280_sensor.ex
@@ -7,13 +7,12 @@ defmodule BMP280.BME280Sensor do
   defstruct [
     :calibration,
     :sea_level_pa,
-    :sensor_type,
     :transport
   ]
 
   defimpl Sensor do
     @impl true
-    def init(%{sensor_type: :bme280, transport: transport} = state) do
+    def init(%{transport: transport} = state) do
       with :ok <- BME280Comm.set_oversampling(transport),
            {:ok, calibration_binary} <- BME280Comm.read_calibration(transport) do
         calibration = BME280Calibration.from_binary(calibration_binary)

--- a/lib/bmp280/sensor/bme280_sensor.ex
+++ b/lib/bmp280/sensor/bme280_sensor.ex
@@ -12,6 +12,7 @@ defmodule BMP280.BME280Sensor do
   ]
 
   defimpl Sensor do
+    @impl true
     def init(%{sensor_type: :bme280, transport: transport} = state) do
       with :ok <- BME280Comm.set_oversampling(transport),
            {:ok, calibration_binary} <- BME280Comm.read_calibration(transport) do
@@ -20,6 +21,7 @@ defmodule BMP280.BME280Sensor do
       end
     end
 
+    @impl true
     def read(%{transport: transport} = state) do
       case BME280Comm.read_raw_samples(transport) do
         {:ok, raw_samples} -> {:ok, BME280Sensor.measurement_from_raw_samples(raw_samples, state)}

--- a/lib/bmp280/sensor/bme680_sensor.ex
+++ b/lib/bmp280/sensor/bme680_sensor.ex
@@ -27,6 +27,7 @@ defmodule BMP280.BME680Sensor do
     @heater_duration_ms 100
     @ambient_temperature_c 25
 
+    @impl true
     def init(%{transport: transport} = initial_state) do
       with :ok <- Comm.reset(transport),
            {:ok, cal_binary} <- BME680Comm.read_calibration(transport),
@@ -52,6 +53,7 @@ defmodule BMP280.BME680Sensor do
            do: %{initial_state | calibration: calibration}
     end
 
+    @impl true
     def read(%{transport: transport} = state) do
       case BME680Comm.read_raw_samples(transport) do
         {:ok, raw_samples} ->

--- a/lib/bmp280/sensor/bme680_sensor.ex
+++ b/lib/bmp280/sensor/bme680_sensor.ex
@@ -7,7 +7,6 @@ defmodule BMP280.BME680Sensor do
   defstruct [
     :calibration,
     :sea_level_pa,
-    :sensor_type,
     :transport
   ]
 

--- a/lib/bmp280/sensor/bmp180_sensor.ex
+++ b/lib/bmp280/sensor/bmp180_sensor.ex
@@ -7,13 +7,12 @@ defmodule BMP280.BMP180Sensor do
   defstruct [
     :calibration,
     :sea_level_pa,
-    :sensor_type,
     :transport
   ]
 
   defimpl Sensor do
     @impl true
-    def init(%{sensor_type: :bmp180, transport: transport} = state) do
+    def init(%{transport: transport} = state) do
       with {:ok, calibration_binary} <- BMP180Comm.read_calibration(transport),
            calibration <- BMP180Calibration.from_binary(calibration_binary),
            do: %{state | calibration: calibration}

--- a/lib/bmp280/sensor/bmp180_sensor.ex
+++ b/lib/bmp280/sensor/bmp180_sensor.ex
@@ -12,12 +12,14 @@ defmodule BMP280.BMP180Sensor do
   ]
 
   defimpl Sensor do
+    @impl true
     def init(%{sensor_type: :bmp180, transport: transport} = state) do
       with {:ok, calibration_binary} <- BMP180Comm.read_calibration(transport),
            calibration <- BMP180Calibration.from_binary(calibration_binary),
            do: %{state | calibration: calibration}
     end
 
+    @impl true
     def read(%{transport: transport} = state) do
       :ok = BMP180Comm.set_temperature_reading(transport)
       Process.sleep(10)

--- a/lib/bmp280/sensor/bmp280_sensor.ex
+++ b/lib/bmp280/sensor/bmp280_sensor.ex
@@ -12,6 +12,7 @@ defmodule BMP280.BMP280Sensor do
   ]
 
   defimpl Sensor do
+    @impl true
     def init(%{sensor_type: :bmp280, transport: transport} = state) do
       with :ok <- BMP280Comm.set_oversampling(transport),
            {:ok, calibration_binary} <- BMP280Comm.read_calibration(transport),
@@ -19,6 +20,7 @@ defmodule BMP280.BMP280Sensor do
            do: %{state | calibration: calibration}
     end
 
+    @impl true
     def read(%{transport: transport} = state) do
       case BMP280Comm.read_raw_samples(transport) do
         {:ok, raw_samples} -> {:ok, BMP280Sensor.measurement_from_raw_samples(raw_samples, state)}

--- a/lib/bmp280/sensor/bmp280_sensor.ex
+++ b/lib/bmp280/sensor/bmp280_sensor.ex
@@ -7,13 +7,12 @@ defmodule BMP280.BMP280Sensor do
   defstruct [
     :calibration,
     :sea_level_pa,
-    :sensor_type,
     :transport
   ]
 
   defimpl Sensor do
     @impl true
-    def init(%{sensor_type: :bmp280, transport: transport} = state) do
+    def init(%{transport: transport} = state) do
       with :ok <- BMP280Comm.set_oversampling(transport),
            {:ok, calibration_binary} <- BMP280Comm.read_calibration(transport),
            calibration <- BMP280Calibration.from_binary(calibration_binary),

--- a/lib/bmp280/sensor/bmp280_sensor.ex
+++ b/lib/bmp280/sensor/bmp280_sensor.ex
@@ -1,27 +1,33 @@
 defmodule BMP280.BMP280Sensor do
   @moduledoc false
 
-  alias BMP280.{Calc, BMP280Calibration, BMP280Comm, Measurement}
+  alias BMP280.{Calc, Measurement, Sensor}
+  alias BMP280.{BMP280Calibration, BMP280Comm, BMP280Sensor}
 
-  @behaviour BMP280.Sensor
+  defstruct [
+    :calibration,
+    :sea_level_pa,
+    :sensor_type,
+    :transport
+  ]
 
-  @impl true
-  def init(%{sensor_type: :bmp280, transport: transport} = state) do
-    with :ok <- BMP280Comm.set_oversampling(transport),
-         {:ok, calibration_binary} <- BMP280Comm.read_calibration(transport),
-         calibration <- BMP280Calibration.from_binary(calibration_binary),
-         do: %{state | calibration: calibration}
-  end
+  defimpl Sensor do
+    def init(%{sensor_type: :bmp280, transport: transport} = state) do
+      with :ok <- BMP280Comm.set_oversampling(transport),
+           {:ok, calibration_binary} <- BMP280Comm.read_calibration(transport),
+           calibration <- BMP280Calibration.from_binary(calibration_binary),
+           do: %{state | calibration: calibration}
+    end
 
-  @impl true
-  def read(%{transport: transport} = state) do
-    case BMP280Comm.read_raw_samples(transport) do
-      {:ok, raw_samples} -> {:ok, measurement_from_raw_samples(raw_samples, state)}
-      error -> error
+    def read(%{transport: transport} = state) do
+      case BMP280Comm.read_raw_samples(transport) do
+        {:ok, raw_samples} -> {:ok, BMP280Sensor.measurement_from_raw_samples(raw_samples, state)}
+        error -> error
+      end
     end
   end
 
-  @spec measurement_from_raw_samples(<<_::48>>, BMP280.Sensor.t()) :: BMP280.Measurement.t()
+  @spec measurement_from_raw_samples(<<_::48>>, Sensor.t()) :: Measurement.t()
   def measurement_from_raw_samples(raw_samples, state) do
     <<raw_pressure::20, _::4, raw_temperature::20, _::4>> = raw_samples
     %{calibration: calibration, sea_level_pa: sea_level_pa} = state


### PR DESCRIPTION
a variant of https://github.com/elixir-sensors/bmp280/pull/51

I really like this version that uses protocol.

I had to wrap my head around for a while because Elixir protocol introduces these keywords `defprotocol` and `defimpl`. Once getting used, I grow on it.

Here are steps:

- define a protocol for an abstract sensor using `defprotocol` (instead of `defmodule`) - `BMP280.Sensor `
- define a struct for each concrete sensor module - `BMP280.BM**80Sensor `
- implement functions that our sensor protocol requires - `init/1` and `read/1`
- that's pretty much it!